### PR TITLE
Add copy method to query

### DIFF
--- a/src/session/query.js
+++ b/src/session/query.js
@@ -8,6 +8,15 @@ export default class Query extends ObservableArray {
     this._type = type;
     this._params = params;
   }
+
+  copy(deep) {
+    const arr = super.copy(deep);
+    const res = new this.constructor(this.session, this.type, this.params);
+
+    res.setObjects(arr.slice());
+
+    return res;
+  }
   
   get params() {
     return this._params;


### PR DESCRIPTION
We need to be able to copy query objects so that we don't manipulate
through reference the original data, while also preserving the `params`
of the query. Originally any call to `copy` would only provide an
`ObservableArray` which lacked the required `params` from the query.

[#140944705]